### PR TITLE
PyTorch Hub Beta to PyTorch Hub Experimental

### DIFF
--- a/_includes/betatoexperimental.html
+++ b/_includes/betatoexperimental.html
@@ -16,7 +16,7 @@
         </a>
         <div class="ecosystem-dropdown-menu">
           <a class="ecosystem-dropdown-item" href="{{ site.baseurl }}/hub">
-            <span class=dropdown-title>Models (Beta)</span>
+            <span class=dropdown-title>Models (Experimental)</span>
             <p>Discover, publish, and reuse pre-trained models</p>
           </a>
           <a class="ecosystem-dropdown-item" href="{{ site.baseurl }}/ecosystem">


### PR DESCRIPTION
Update the term "Beta" to "Experimental" to stay aligned in all other future launches.